### PR TITLE
Fix update of GUI widgets for all guis and generalize ChannelState

### DIFF
--- a/caengui.py
+++ b/caengui.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import tkinter as tk
 import argparse
 import threading
+from channel import ChannelState
 import hvps
 
 CHANNEL_NAMES = ["mesh right", "mesh left", "gem top", "gem bottom"]
@@ -51,9 +52,30 @@ class CaenHVPSGUI(DeviceGUI):
                 if i >= len(channel_names):
                     channel_names[i] = f"Channel {i}"
 
-        super().__init__(module, channel_names, parent_frame,
+        channels_states = {}
+        for name in CHANNEL_NAMES:
+            channels_states[name] = ChannelState(
+                    name,
+                    ["vset", "vmon", "imon", "stat"],
+                    thresholds={"vmon": 0.5, "imon": 0.01},
+                    precisions={"vmon": 1, "imon": 3},
+                    units={"vset": "V", "vmon": "V", "imon": "uA"},
+                    save_value={"vset": False, "vmon": True, "imon": True, "stat": False},
+                )
+        channels_states["board"] = ChannelState(
+                "board",
+                ["board_alarm_status", "interlock_status"],
+                save_value={"board_alarm_status": False, "interlock_status": False},
+                thresholds={"board_alarm_status": 0, "interlock_status": 0},
+                precisions={"board_alarm_status": 0, "interlock_status": 0},
+                units={"board_alarm_status": "", "interlock_status": ""},
+            )
+
+        super().__init__(
+                        device=module,
+                        channels_states=channels_states,
+                        parent_frame=parent_frame,
                         logging_enabled=log,
-                        channel_state_save_previous=False,
                         )
 
 
@@ -527,16 +549,28 @@ class CaenHVPSGUI(DeviceGUI):
             vset = ch.vset
             vmon = ch.vmon
             imon = ch.imon
-            self.channels_state[i].set_state(vmon, imon)
-            self.vset_labels[i].config(text=f"{vset:.1f}")
-            self.vmon_labels[i].config(text=f"{vmon:.1f}")
-            self.imon_labels[i].config(text=f"{imon:.3f}")
-            self.update_state_indicator(i, ch)
-        self.update_alarm_indicators()
+            self.channels_state[self.channels_name[i]].set_state(
+                {"vset": vset, "vmon": vmon, "imon": imon, "stat": ch.stat.copy()})
+        self.channels_state["board"].set_state({
+            "board_alarm_status": self.device.board_alarm_status.copy(),
+            "interlock_status": self.device.interlock_status,
+        })
 
-    def update_state_indicator(self, channel_number, channel):
+    def update_gui(self):
+        for i, ch in enumerate(self.device.channels):
+            values = self.channels_state[self.channels_name[i]].get_values()
+            self.vset_labels[i].config(text=f"{values.get('vset', -1):.1f}")
+            self.vmon_labels[i].config(text=f"{values.get('vmon', -1):.1f}")
+            self.imon_labels[i].config(text=f"{values.get('imon', -1):.3f}")
+            self.update_state_indicator(i, values.get("stat", {}))
+        values_board = self.channels_state["board"].get_values()
+        self.update_alarm_indicators(
+            board_alarm_status=values_board.get("board_alarm_status", {}),
+            interlock_status=values_board.get("interlock_status", False),
+        )
+    def update_state_indicator(self, channel_number, status):
         # Update the state indicator
-        stat = channel.stat.copy()
+        stat = status.copy()
         if stat["TRIP"]:
             state_indicator_color = "red"
             state_tooltip_text = "TRIP"
@@ -563,9 +597,9 @@ class CaenHVPSGUI(DeviceGUI):
         self.state_indicators[channel_number].itemconfig(1, fill=state_indicator_color)
         self.state_tooltips[channel_number].change_text(f"State: {state_tooltip_text}")
 
-    def update_alarm_indicators(self):
-        bas = self.device.board_alarm_status.copy()
-        ilk = self.device.interlock_status
+    def update_alarm_indicators(self, board_alarm_status=None, interlock_status=None):
+        bas = board_alarm_status.copy() if board_alarm_status is not None else {}
+        ilk = interlock_status if interlock_status is not None else False
         self.alarm_indicator.itemconfig(
             1,
             fill="red"

--- a/channel.py
+++ b/channel.py
@@ -1,0 +1,237 @@
+import datetime as dt
+import os
+import logging
+import queue
+import threading
+import requests
+import json
+
+import copy
+import csv
+import datetime as dt
+from dataclasses import dataclass, field
+from pathlib import Path
+
+LOG_DIR = "logs"
+
+def create_directory_recursive(path):
+    try:
+        directory = os.path.dirname(path)
+        os.makedirs(directory, exist_ok=True)
+    except Exception as e:
+        print(f"Error occurred while creating directory '{path}': {e}")
+
+def get_path_from_date(dt_obj):
+    return LOG_DIR + "/" + dt_obj.strftime("%Y/%m/%d")
+
+def get_full_filename_from_date(dt_obj, suffix="", extension="dat"):
+    path = get_path_from_date(dt_obj)
+    return f"{path}/{dt_obj.strftime('%Y%m%d')}_{suffix}.{extension}"
+
+
+# ============================================================
+# Generic immutable state snapshot
+# ============================================================
+
+@dataclass(frozen=True)
+class State:
+    """
+    Generic immutable snapshot of channel/device state.
+    """
+    timestamp: dt.datetime = field(default_factory=dt.datetime.now)
+    values: dict = field(default_factory=dict)
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    def to_dict(self):
+        return {
+            "timestamp": self.timestamp,
+            **self.values
+        }
+
+    def __str__(self):
+
+        values_str = ", ".join(
+            f"{k}: {v} ({self.units.get(k, '')})".strip()
+            for k, v in self.values.items()
+        )
+
+        return f"{self.timestamp} | {values_str}"
+
+
+# ============================================================
+# Generic channel state manager
+# ============================================================
+class ChannelState:
+    """
+    Generic state manager for any device channel.
+
+    Features:
+    - current/previous/last_saved snapshots
+    - generic variable support
+    - threshold-based logging
+    - CSV writing
+    - immutable state snapshots
+    """
+
+    def __init__(self, channel_name, value_names, thresholds=None, precisions=None, units=None, save_value=None):
+
+        self.name = channel_name
+        self.value_names = value_names
+
+        # Thresholds for deciding whether a value changed enough to trigger logging.
+        # Example: { "vmon": 0.5, "imon": 0.01, "pressure": 0.1,}
+        self.thresholds = thresholds or {}
+
+        # Precision for file output (number of decimal places) for specific variables.Example:{"vmon": 1,"imon": 3,}
+        self.precisions = precisions or {}
+        
+        # Units for display purposes. Example: {"vmon": "V", "imon": "A", "pressure": "mbar",}
+        self.units = units or {}
+        
+        # flag to decide whether to save a specific variable (if None, all are saved). Example: {"vmon": True, "imon": True, "pressure": False,}
+        self.save_value = save_value or {}
+
+        # Initialize state snapshots
+        self.current = State()
+        self.previous = State()
+        self.last_saved = State()
+        
+        self.lock = threading.Lock()
+
+    def set_state(self, values: dict):
+        # check that values has the expected keys
+        for key in self.value_names:
+            if key not in values:
+                raise ValueError(f"Missing value for '{key}' in channel '{self.name}'")
+
+        with self.lock:
+            self.previous = self.current
+            self.current = State(values=copy.deepcopy(values))
+    
+    def get_value(self, key, default=None):
+        with self.lock:
+            return self.current.get(key, default)
+    
+    def get_state(self):
+        with self.lock:
+            return self.current
+    
+    def get_values(self):
+        with self.lock:
+            return self.current.values.copy()
+
+    def is_different(self):
+        for key, threshold in self.thresholds.items():
+            current_value = self.current.get(key)
+            saved_value = self.last_saved.get(key)
+
+            if current_value is None and saved_value is None:
+                continue
+            
+            if current_value is not None and saved_value is None:
+                return True
+
+            # numeric threshold comparison
+            if isinstance(current_value, (int, float)):
+                if abs(current_value - saved_value) >= threshold:
+                    return True
+            # non-numeric direct comparison
+            else:
+                if current_value != saved_value:
+                    return True
+
+        return False
+
+    # ========================================================
+    # Logging
+    # ========================================================
+    def save_state(self, force=False, save_previous=True):
+        with self.lock:
+            if not (force or self.is_different()):
+                return
+            filename = get_full_filename_from_date(self.current.timestamp, suffix=self.name.replace(" ", ""))
+            if self.last_saved != self.previous and save_previous:
+                self.write_state_to_file(self.previous, filename, delimiter=' ')
+            self.write_state_to_file(self.current, filename, delimiter=' ')
+            self.last_saved = self.current
+
+    def file_header_row(self):
+        header = ["Time"]
+        for key in self.value_names:
+            if not self.save_value.get(key, True):
+                continue
+            header.append(f"{key}[{self.units.get(key, '')}]")
+        return header
+        
+    def file_header_str(self, delimiter=","):
+        row = self.file_header_row()
+        if len(row) <= 1: # Only timestamp, no values
+            return ""
+        return delimiter.join(row)
+
+    def _state_to_row(self, state: State):
+
+        row = [state.timestamp.strftime("%Y-%m-%d %H:%M:%S")]
+
+        for key, value in state.values.items():
+            if not self.save_value.get(key, True):
+                continue
+            precision = self.precisions.get(key)
+            if (
+                precision is not None
+                and isinstance(value, (int, float))
+            ):
+                value = f"{value:.{precision}f}"
+            row.append(value)
+
+        return row
+    
+    def _state_to_str(self, state: State, delimiter=" "):
+        row = self._state_to_row(state)
+        if len(row) <= 1: # Only timestamp, no values
+            return ""
+        return delimiter.join(row)
+
+    def _build_filename(self, directory):
+        date_str = self.current.timestamp.strftime("%Y-%m-%d")
+        safe_name = self.channel_name.replace(" ", "_")
+        path = Path(directory)
+        path.mkdir(parents=True, exist_ok=True)
+        return path / f"{date_str}_{safe_name}.csv"
+    
+    def write_state_to_file(self, state: State, filename: str, delimiter=' '):
+        create_directory_recursive(filename)
+        if not os.path.isfile(filename):
+            try:
+                # create the file if it does not exist
+                header_str = self.file_header_str(delimiter=delimiter)
+                if not header_str: # no values to write, skip creating the file
+                    return
+                with open(filename, 'w') as file:
+                    file.write(self.file_header_str(delimiter=delimiter) + "\n")
+                print("Writing to new file:", filename)
+            except:
+                print("Invalid file or directory:", filename)
+
+        row_str = self._state_to_str(state, delimiter=delimiter) # empty string if only timestamp and no values to save
+        if not row_str: # no values to write, skip writing the row
+            return
+        with open(filename, 'a') as file:
+            file.write(row_str + "\n")
+
+
+    def to_dict(self):
+        return {
+            "channel": self.channel_name,
+            "current": self.current.to_dict(),
+            "previous": self.previous.to_dict(),
+            "last_saved": self.last_saved.to_dict(),
+        }
+
+    def __str__(self):
+        return (
+            f"{self.name} | "
+            f"{self.current}"
+        )

--- a/checkframe.py
+++ b/checkframe.py
@@ -23,6 +23,7 @@ class ChecksFrame:
         self.checks_vars = []
         self.checks_checkboxes = []
         self.checks_tooltips = []
+        self.checks_states = []
         self.edit_checks_button = None
 
         self.config_params = {
@@ -75,6 +76,7 @@ class ChecksFrame:
         self.checks_checkboxes = []
         self.checks_tooltips = []
         for i, check in enumerate(self.checks):
+            self.checks_states.append("unavailable")
             var = tk.BooleanVar()
             var.set(check.is_available())
             self.checks_vars.append(var)
@@ -161,6 +163,7 @@ class ChecksFrame:
             cancel_button.grid(row=len(name_entries)+2, column=0, padx=10, pady=10, sticky="e")
             apply_button.grid(row=len(name_entries)+2, column=1, padx=10, pady=10, sticky="w")
             # add the check to the list
+            self.checks_states.append("unavailable")
             self.checks_vars.append(tk.BooleanVar())
             self.checks_vars[-1].set(False)
             self.checks_vars[-1].trace_variable("w", lambda *args, x=len(self.checks)-1: self.checks[x].set_active(self.checks_vars[x].get()))
@@ -226,23 +229,13 @@ class ChecksFrame:
             current_bg_color = self.checks_checkboxes[i].cget("bg")
             current_fg_color = self.checks_checkboxes[i].cget("fg")
             if not check.is_available():
-                if current_bg_color != "gray":
-                    self.checks_checkboxes[i].config(bg=frame_bg_color)
-                if current_fg_color != "black":
-                    self.checks_checkboxes[i].config(fg="black")
+                self.checks_states[i] = "unavailable"
                 continue
             if check.eval_condition():
-                if current_fg_color != "green":
-                    self.checks_checkboxes[i].config(fg="green")
-                if current_bg_color != frame_bg_color:
-                    self.checks_checkboxes[i].config(bg=frame_bg_color)
+                self.checks_states[i] = "passed"
             else:
-                all_available_checks_passed = False
-                if current_fg_color != "black":
-                    self.checks_checkboxes[i].config(fg="black")
-                if current_bg_color != "red":
-                    self.checks_checkboxes[i].config(bg="red")
-                    print(f"Check '{check.name}' failed")
+                if self.checks_states[i] != "failed":
+                    self.checks_states[i] = "failed"
                     failed_checks.append(check)
         if failed_checks:
             message = "\n".join([f"Check '{check.name}' failed." for check in failed_checks])
@@ -252,6 +245,7 @@ class ChecksFrame:
                         "Warning", message, parent=self.root
                     )
                 ).start() # show the warning in a new thread to avoid blocking the main thread until the warning is closed
+        self.root.after(10, self.update_gui)
         return failed_checks == []
     
     def simulate_check_conditions(self, parameters_values : dict):
@@ -261,23 +255,13 @@ class ChecksFrame:
             current_bg_color = self.checks_checkboxes[i].cget("bg")
             current_fg_color = self.checks_checkboxes[i].cget("fg")
             if not check.is_available():
-                if current_bg_color != "gray":
-                    self.checks_checkboxes[i].config(bg=frame_bg_color)
-                if current_fg_color != "black":
-                    self.checks_checkboxes[i].config(fg="black")
+                self.checks_states[i] = "unavailable"
                 continue
             if check.simulate_eval_condition(parameters_values):
-                if current_fg_color != "green":
-                    self.checks_checkboxes[i].config(fg="green")
-                if current_bg_color != frame_bg_color:
-                    self.checks_checkboxes[i].config(bg=frame_bg_color)
+                self.checks_states[i] = "passed"
             else:
-                all_available_checks_passed = False
-                if current_fg_color != "black":
-                    self.checks_checkboxes[i].config(fg="black")
-                if current_bg_color != "red":
-                    self.checks_checkboxes[i].config(bg="red")
-                    print(f"Check '{check.name}' failed")
+                if self.checks_states[i] != "failed":
+                    self.checks_states[i] = "failed"
                     failed_checks.append(check)
         if failed_checks:
             message = "\n".join([f"Simulated check '{check.name}' failed." for check in failed_checks])
@@ -287,7 +271,32 @@ class ChecksFrame:
                         "Warning", message, parent=self.root
                     )
                 ).start() # show the warning in a new thread to avoid blocking the main thread until the warning is closed
+        self.root.after(10, self.update_gui)
         return failed_checks == []
+    
+    def update_gui(self):
+        for i, check_state in enumerate(self.checks_states):
+            frame_bg_color = self.frame.cget("bg")
+            current_bg_color = self.checks_checkboxes[i].cget("bg")
+            current_fg_color = self.checks_checkboxes[i].cget("fg")
+            if check_state == "unavailable":
+                if current_bg_color != "gray":
+                    self.checks_checkboxes[i].config(bg=frame_bg_color)
+                if current_fg_color != "black":
+                    self.checks_checkboxes[i].config(fg="black")
+            elif check_state == "passed":
+                if current_fg_color != "green":
+                    self.checks_checkboxes[i].config(fg="green")
+                if current_bg_color != frame_bg_color:
+                    self.checks_checkboxes[i].config(bg=frame_bg_color)
+            elif check_state == "failed":
+                if current_fg_color != "black":
+                    self.checks_checkboxes[i].config(fg="black")
+                if current_bg_color != "red":
+                    self.checks_checkboxes[i].config(bg="red")
+            else:
+                print(f"Warning: check state '{check_state}' is not valid.")
+                self.checks_checkboxes[i].config(bg="blue", fg="orange")
 
     def check_loop(self):
         while True:

--- a/daqmetricsgui.py
+++ b/daqmetricsgui.py
@@ -39,7 +39,7 @@ class DaqMetricsGUI(DeviceGUI):
 
         super().__init__(
                         device=daqmetrics,
-                        channels_name=[],
+                        channels_states={},
                         parent_frame=parent_frame,
                         logging_enabled=False,
                         read_loop_time=60,
@@ -148,18 +148,10 @@ class DaqMetricsGUI(DeviceGUI):
         self.add_to_googlesheet_thread = threading.Thread(target=add_run)
         self.add_to_googlesheet_thread.start()
 
-    def read_values(self):
-
-        self.daqmetrics.fetch_everything()
+    def update_gui(self):
         if self.daqmetrics.fetcher.metrics:
-            #output_filename = self.daqmetrics.get_filename()
             run_tag = self.daqmetrics.get_run_tag()
             self.run_number_label.config(text=f'{self.daqmetrics.get_run_number():.0f}')
-            if self.daqmetrics.get_metric("run_number") != 0:
-                if self.add_to_googlesheet_thread and self.add_to_googlesheet_thread.is_alive():
-                    pass
-                else:
-                    self.add_to_googlesheet_button.config(state="normal")
             self.run_tag_label.config(text=run_tag if run_tag else "")
             run_duration = self.daqmetrics.get_run_time_seconds()
             run_start = self.daqmetrics.get_run_start_time()
@@ -171,10 +163,41 @@ class DaqMetricsGUI(DeviceGUI):
                 endtime = None
                 self.run_starttime_label.config(text=f'')
                 self.run_endtime_label.config(text=f'')
-                
+
             self.daq_events_label.config(text=f'{self.daqmetrics.get_rate():.2f}')
             number_of_events = self.daqmetrics.get_number_of_events()
             self.events_number_label.config(text=f'{number_of_events:,.0f}')
+            
+            run_tag = self.daqmetrics.get_run_tag()
+            if any(b in run_tag.lower() for b in ["background", "bg", "bckg", "bkg"]):
+                if run_duration < 24*3600: # to catch when run is launched without changing the calibration LOOP time
+                    self.run_endtime_label.config(fg="red")
+                else:
+                    self.run_endtime_label.config(fg="black") # TODO: better to go back to default color
+            subrun_number = self.daqmetrics.get_subrun_number()
+            self.subrun_number_label.config(text=f'{subrun_number}')
+        else:
+            self.run_number_label.config(text="N/A")
+            self.run_tag_label.config(text="N/A")
+            self.run_starttime_label.config(text="N/A")
+            self.run_endtime_label.config(text="N/A")
+            self.daq_events_label.config(text="N/A")
+            self.events_number_label.config(text="N/A")
+            self.subrun_number_label.config(text="N/A")
+            self.add_to_googlesheet_button.config(state="disabled")
+            # don't reset here the number of entries and datetime_last_entries_change, just in case the metrics server is down for a while
+
+    def read_values(self):
+        self.daqmetrics.fetch_everything()
+        if self.daqmetrics.fetcher.metrics:
+            # enable the "Add to Google Sheet" button
+            if self.daqmetrics.get_metric("run_number") != 0:
+                if self.add_to_googlesheet_thread and self.add_to_googlesheet_thread.is_alive():
+                    pass
+                else:
+                    self.add_to_googlesheet_button.config(state="normal")
+
+            number_of_events = self.daqmetrics.get_number_of_events()
 
             # Checking if the number of entries is changing is done as an indirect way to check if the TCM is running fine
             if self.check_entries_var.get() == 1:
@@ -204,27 +227,18 @@ class DaqMetricsGUI(DeviceGUI):
                 self.alarm_level_sent = logging.NOTSET
             
             # Check for background runs that have finished or will finish soon
+            run_tag = self.daqmetrics.get_run_tag()
+            run_duration = self.daqmetrics.get_run_time_seconds()
+            run_start = self.daqmetrics.get_run_start_time()
+            if run_start is not None:
+                endtime = run_start + datetime.timedelta(seconds=run_duration)
+            else:
+                endtime = None
             if any(b in run_tag.lower() for b in ["background", "bg", "bckg", "bkg"]):
-                if run_duration < 24*3600: # to catch when run is launched without changing the calibration LOOP time
-                    self.run_endtime_label.config(fg="red")
-                else:
-                    self.run_endtime_label.config(fg="black") # TODO: better to go back to default color
-
                 if endtime and endtime < datetime.datetime.now(): # catch if run has finished
                     self.logger.error(f"Background run {int(self.daqmetrics.get_metric('run_number'))} has finished!")
 
-            subrun_number = self.daqmetrics.get_subrun_number()
-            self.subrun_number_label.config(text=f'{subrun_number}')
-        else:
-            self.run_number_label.config(text="N/A")
-            self.run_tag_label.config(text="N/A")
-            self.run_starttime_label.config(text="N/A")
-            self.run_endtime_label.config(text="N/A")
-            self.daq_events_label.config(text="N/A")
-            self.events_number_label.config(text="N/A")
-            self.subrun_number_label.config(text="N/A")
-            self.add_to_googlesheet_button.config(state="disabled")
-            # don't reset here the number of entries and datetime_last_entries_change, just in case the metrics server is down for a while
+        # auto-add to google sheet if new run is detected and auto-add is enabled
         if (
             self.auto_add_var.get() == 1
             and self.run_number_label.cget("text") != "N/A"

--- a/devicegui.py
+++ b/devicegui.py
@@ -27,50 +27,38 @@ class DeviceGUI(ABC):
         - read_loop_time (float): Time interval for reading channel data (default: 1 second).
     """
 
-    def __init__(self, device, channels_name: list, parent_frame=None, **kwargs):
+    def __init__(self, device, channels_states, parent_frame=None, **kwargs):
         self.device = device
-        self.channels_name = channels_name
-        self.channels_state = None
+        self.channels_state = channels_states.copy()
+        self.channels_name = list(channels_states.keys())
 
         self.config_params = {
             "logging_enabled" : kwargs.get("logging_enabled", True),
-            "channel_state_save_previous" : kwargs.get("channel_state_save_previous", True),
-            "channel_state_save_force" : kwargs.get("channel_state_save_force", False),
-            "channel_state_diff_vmon" : kwargs.get("channel_state_diff_vmon", 0.5),
-            "channel_state_diff_imon" : kwargs.get("channel_state_diff_imon", 0.01),
-            "channel_state_prec_vmon" : kwargs.get("channel_state_prec_vmon", 1),
-            "channel_state_prec_imon" : kwargs.get("channel_state_prec_imon", 3),
             "read_loop_time" : kwargs.get("read_loop_time", 1),
+            "gui_update_time" : kwargs.get("gui_update_time", 1),
         }
+        
+        base_channel_params = {
+            "save_previous": False,
+            "save_force": False,
+            "thresholds": {},
+            "precisions": {},
+        }
+        
+        self.config_channels_params = {}
+        for name in self.channels_name:
+            self.config_channels_params[name] = base_channel_params.copy()
+            if self.channels_state.get(name):
+                # if the channel state is already provided, use its parameters as default
+                chstate = self.channels_state[name]
+                self.config_channels_params[name]["thresholds"] = chstate.thresholds
+                self.config_channels_params[name]["precisions"] = chstate.precisions
 
         # Validate input parameters
         if not isinstance(self.config_params["logging_enabled"], bool):
             raise ValueError("logging_enabled must be a boolean")
-        if not isinstance(self.config_params["channel_state_save_previous"], bool):
-            raise ValueError("channels_state_save_previous must be a boolean")
-        if not isinstance(self.config_params["channel_state_prec_vmon"], int) or self.config_params["channel_state_prec_vmon"] < 0:
-            raise ValueError("channels_state_prec_vmon must be a positive integer")
-        if not isinstance(self.config_params["channel_state_prec_imon"], int) or self.config_params["channel_state_prec_imon"] < 0:
-            raise ValueError("channels_state_prec_imon must be a positive integer")
-        if not isinstance(self.config_params["channel_state_diff_vmon"], (int, float)) or self.config_params["channel_state_diff_vmon"] < 0:
-            raise ValueError("channels_state_diff_vmon must be a positive number")
-        if not isinstance(self.config_params["channel_state_diff_imon"], (int, float)) or self.config_params["channel_state_diff_imon"] < 0:
-            raise ValueError("channels_state_diff_imon must be a positive number")
         if not isinstance(self.config_params["read_loop_time"], (int, float)) or self.config_params["read_loop_time"] <= 0:
             raise ValueError("read_loop_time must be a positive number")
-
-        # Initialize channel states
-        if self.channels_state is None:
-            self.channels_state = [
-                ChannelState(
-                    name,
-                    diff_vmon=self.config_params["channel_state_diff_vmon"],
-                    diff_imon=self.config_params["channel_state_diff_imon"],
-                    precision_vmon=self.config_params["channel_state_prec_vmon"],
-                    precision_imon=self.config_params["channel_state_prec_imon"],
-                )
-                for name in self.channels_name
-            ]
 
         # Initialize GUI basic components
         start_mainloop = False
@@ -110,7 +98,7 @@ class DeviceGUI(ABC):
         # Create GUI
         self.create_gui()
         self.start_background_threads()
-
+        self.schedule_gui_update()
         if start_mainloop:
             self.root.mainloop() # this will block the main thread until the window is closed
 
@@ -142,14 +130,25 @@ class DeviceGUI(ABC):
         threading.Thread(target=self.read_loop, daemon=True).start()
         threading.Thread(target=self.process_commands, daemon=True).start()
 
+    def schedule_gui_update(self):
+            try:
+                self.update_gui()
+            except Exception as e:
+                self.logger.exception(f"{self.device.name} GUI update failed: {e}")
+
+            self.root.after(
+                self.config_params["gui_update_time"]*1000, # convert s to ms
+                self.schedule_gui_update
+            )
+
     def read_loop(self):
         while True:
             self.issue_command(self.read_values)
             if self.config_params["logging_enabled"]:
-                for chstate in self.channels_state:
+                for name, chstate in self.channels_state.items():
                     chstate.save_state(
-                        save_previous=self.config_params["channel_state_save_previous"],
-                        force=self.config_params["channel_state_save_force"],
+                        save_previous=self.config_channels_params[name]["save_previous"],
+                        force=self.config_channels_params[name]["save_force"],
                     )
             time.sleep(self.config_params["read_loop_time"])
 
@@ -226,6 +225,10 @@ class DeviceGUI(ABC):
     
     @abstractmethod
     def read_values(self):
+        pass
+    
+    @abstractmethod
+    def update_gui(self):
         pass
     
     @abstractmethod

--- a/spellmangui.py
+++ b/spellmangui.py
@@ -3,7 +3,7 @@ import argparse
 
 # import spellmanModule as spll  # Assuming spellmanModule has required functions
 from spellmanClass import Spellman
-from logger import ChannelState
+from channel import ChannelState
 from checkframe import ChecksFrame
 from devicegui import DeviceGUI
 from utilsgui import ToolTip
@@ -21,14 +21,21 @@ class SpellmanFrame(DeviceGUI):
         self.state_tooltip = None
         self.security_frame = None
         self.checks_frame = None
+        
+        channelstate = ChannelState(
+            channel_name='cathode',
+            value_names=['vset', 'iset','vmon', 'imon', 'stat'],
+            thresholds={'vmon': 50, 'imon': 999},
+            precisions={'vmon': 0, 'imon': 5},
+            units={'vset': 'V', 'iset': 'mA', 'vmon': 'V', 'imon': 'mA'},
+            save_value={'vset': False, 'iset': False, 'vmon': True, 'imon': True, 'stat': False},
+            )
 
-        super().__init__(spellman, ['cathode'], parent,
+        super().__init__(
+                        device=spellman,
+                        channels_states={'cathode': channelstate},
+                        parent_frame=parent,
                         logging_enabled=log,
-                        channel_state_save_previous=False,
-                        channel_state_diff_vmon=50,
-                        channel_state_diff_imon=999,
-                        channel_state_prec_vmon=0,
-                        channel_state_prec_imon=5,
                         read_loop_time=2,
                         )
 
@@ -281,17 +288,32 @@ class SpellmanFrame(DeviceGUI):
         imon = self.device.imon
         vset = self.device.vset
         iset = self.device.iset
-        self.channels_state[0].set_state(vmon, imon)
+        stat = self.device.stat
+        self.channels_state['cathode'].set_state(
+            {
+                'vmon': vmon,
+                'imon': imon,
+                'vset': vset,
+                'iset': iset,
+                'stat': stat,
+            }
+        )
+    
+    def update_gui(self):
+        values = self.channels_state['cathode'].get_values()
+        vmon = values.get('vmon', -1)
+        imon = values.get('imon', -1)
+        vset = values.get('vset', -1)
+        iset = values.get('iset', -1)
+        stat = values.get('stat', {})
+        remote = stat.get('REMOTE', '--')
+        hv = stat.get('HV', '--')
+        arc = stat.get('ARC', '--')
+
         self.label_vars['voltage'].set(f"{vmon:.0f}")
         self.labels['current_s'].config(text=f"{imon:.5f}")
         self.labels['voltage_dac_label'].config(text=f"{vset:.0f}")
         self.labels['current_dac_label'].config(text=f"{iset:.5f}")
-
-        stat = self.device.stat
-        remote = stat['REMOTE']
-        hv = stat['HV']
-        arc = stat['ARC']
-
         if isinstance(remote, bool):
             self.labels['remote_s'].config(text='ON' if remote else 'OFF')
             self.labels['remote_s'].config(fg='green' if remote else 'red')
@@ -308,7 +330,7 @@ class SpellmanFrame(DeviceGUI):
 
         if isinstance(arc, bool):
             self.labels['arc'].config(text='ARC' if arc else 'no arc')
-            self.labels['arc'].config(fg='red' if arc else 'black')
+            #self.labels['arc'].config(fg='red' if arc else 'black')
         else:
             self.labels['arc'].config(text=arc)
             self.labels['arc'].config(fg='black')

--- a/trex_HV_gui.py
+++ b/trex_HV_gui.py
@@ -113,7 +113,7 @@ class HVGUI:
             self.caen_frame.pack(side="left", fill="x", anchor="n", expand=True)
             self.caen_gui = caengui.CaenHVPSGUI(module=self.caen_module, parent_frame=self.caen_frame,
                                                 channel_names=caengui.CHANNEL_NAMES, checks=self.caen_checks, silence=False, log=self.logging_enabled)
-            self.all_channels = {name: self.caen_module.channels[i] for i, name in enumerate(self.caen_gui.channels_name)}
+            self.all_channels = {name: self.caen_module.channels[i] for i, name in enumerate(self.caen_gui.channels_name) if i < len(self.caen_module.channels)} # to avoid adding the board
             self.channels_gui = {name: self.caen_gui for name in self.caen_gui.channels_name}
             self.all_guis['caen'] = self.caen_gui
             self.channels_vmon_guilabel = {name: label for name, label in zip(self.caen_gui.channels_name, self.caen_gui.vmon_labels)}


### PR DESCRIPTION
Currently the tkinter widgets are updated in secondary threads. This seem to work but sometimes (when closing the gui or when Spellman cannot be reached) the program crashes. Although this has not been a problem so far, it is not reliable and it may cause serious problems if the GUI grows.

As I am thinking of implementing the gas SC here also, it is a good oportunity to fix this beforehand.

To be able to separate the updating of tkinter widgets from the reading loop, the ChannelState must be generalized so it can serve as link between the reading and the updating of the gui widgets.

Tasks:

- [x] Generalize ChannelState and State
- [x] Separate update_gui and read_values in DeviceGUI 
- [x] Adapt caengui to the new DeviceGUI
- [x] Adapt spellmangui to the new DeviceGUI
- [x] Adapt daqmetricsgui to the new DeviceGUI
- [x] Separate the updating of guis also in CheckFrame
- [x] Separate the updating of gui in DaqMetricsGUI

Smaller tasks:

- [ ] Add menu to configure channel params in devicegui
